### PR TITLE
Toggle add forms with expanders

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,17 @@ if 'events' not in st.session_state:
 if 'transactions' not in st.session_state:
     st.session_state.transactions = []
 
+if 'show_add_client' not in st.session_state:
+    st.session_state.show_add_client = False
+if 'show_add_case' not in st.session_state:
+    st.session_state.show_add_case = False
+if 'show_add_task' not in st.session_state:
+    st.session_state.show_add_task = False
+if 'show_add_event' not in st.session_state:
+    st.session_state.show_add_event = False
+if 'show_add_transaction' not in st.session_state:
+    st.session_state.show_add_transaction = False
+
 menu = st.sidebar.selectbox(
     "Menu",[
         "Visão Geral",
@@ -81,15 +92,18 @@ if menu == "Visão Geral":
 
 elif menu == "Clientes":
     st.title("Clientes")
-    with st.form("add_client"):
-        st.subheader("Adicionar Cliente")
-        name = st.text_input("Nome")
-        email = st.text_input("Email")
-        phone = st.text_input("Telefone")
-        submitted = st.form_submit_button("Adicionar")
-        if submitted:
-            add_client(name, email, phone)
-            st.success("Cliente adicionado")
+    if st.button("Adicionar Cliente"):
+        st.session_state.show_add_client = not st.session_state.show_add_client
+    if st.session_state.show_add_client:
+        with st.expander("Adicionar Cliente", expanded=True):
+            with st.form("add_client"):
+                name = st.text_input("Nome")
+                email = st.text_input("Email")
+                phone = st.text_input("Telefone")
+                submitted = st.form_submit_button("Salvar")
+                if submitted:
+                    add_client(name, email, phone)
+                    st.success("Cliente adicionado")
     st.subheader("Lista de Clientes")
     if st.session_state.clients:
         st.table(st.session_state.clients)
@@ -98,17 +112,23 @@ elif menu == "Clientes":
 
 elif menu == "Casos":
     st.title("Casos")
-    with st.form("add_case"):
-        st.subheader("Adicionar Caso")
-        title = st.text_input("Título")
-        client = st.selectbox("Cliente", [c['Nome'] for c in st.session_state.clients]) if st.session_state.clients else st.text_input("Cliente")
-        description = st.text_area("Descrição")
-        status = st.selectbox("Status", ["Aberto", "Em andamento", "Fechado"])
-        start_date = st.date_input("Data de início", value=date.today())
-        submitted = st.form_submit_button("Adicionar")
-        if submitted:
-            add_case(title, client, description, status, start_date)
-            st.success("Caso adicionado")
+    if st.button("Adicionar Caso"):
+        st.session_state.show_add_case = not st.session_state.show_add_case
+    if st.session_state.show_add_case:
+        with st.expander("Adicionar Caso", expanded=True):
+            with st.form("add_case"):
+                title = st.text_input("Título")
+                client = st.selectbox(
+                    "Cliente",
+                    [c['Nome'] for c in st.session_state.clients]
+                ) if st.session_state.clients else st.text_input("Cliente")
+                description = st.text_area("Descrição")
+                status = st.selectbox("Status", ["Aberto", "Em andamento", "Fechado"])
+                start_date = st.date_input("Data de início", value=date.today())
+                submitted = st.form_submit_button("Salvar")
+                if submitted:
+                    add_case(title, client, description, status, start_date)
+                    st.success("Caso adicionado")
     st.subheader("Lista de Casos")
     if st.session_state.cases:
         st.table(st.session_state.cases)
@@ -117,15 +137,18 @@ elif menu == "Casos":
 
 elif menu == "Agenda":
     st.title("Agenda")
-    with st.form("add_event"):
-        st.subheader("Adicionar Evento")
-        title = st.text_input("Título")
-        event_date = st.date_input("Data", value=date.today())
-        description = st.text_area("Descrição")
-        submitted = st.form_submit_button("Adicionar")
-        if submitted:
-            add_event(title, event_date, description)
-            st.success("Evento adicionado")
+    if st.button("Adicionar Evento"):
+        st.session_state.show_add_event = not st.session_state.show_add_event
+    if st.session_state.show_add_event:
+        with st.expander("Adicionar Evento", expanded=True):
+            with st.form("add_event"):
+                title = st.text_input("Título")
+                event_date = st.date_input("Data", value=date.today())
+                description = st.text_area("Descrição")
+                submitted = st.form_submit_button("Salvar")
+                if submitted:
+                    add_event(title, event_date, description)
+                    st.success("Evento adicionado")
     st.subheader("Eventos")
     if st.session_state.events:
         st.table(st.session_state.events)
@@ -134,16 +157,24 @@ elif menu == "Agenda":
 
 elif menu == "Tarefas":
     st.title("Tarefas")
-    with st.form("add_task"):
-        st.subheader("Adicionar Tarefa")
-        title = st.text_input("Título")
-        due_date = st.date_input("Data limite", value=date.today())
-        related_case = st.selectbox("Caso", [c['Título'] for c in st.session_state.cases]) if st.session_state.cases else st.text_input("Caso")
-        status = st.selectbox("Status", ["Pendente", "Em andamento", "Concluída"])
-        submitted = st.form_submit_button("Adicionar")
-        if submitted:
-            add_task(title, due_date, related_case, status)
-            st.success("Tarefa adicionada")
+    if st.button("Adicionar Tarefa"):
+        st.session_state.show_add_task = not st.session_state.show_add_task
+    if st.session_state.show_add_task:
+        with st.expander("Adicionar Tarefa", expanded=True):
+            with st.form("add_task"):
+                title = st.text_input("Título")
+                due_date = st.date_input("Data limite", value=date.today())
+                related_case = st.selectbox(
+                    "Caso",
+                    [c['Título'] for c in st.session_state.cases]
+                ) if st.session_state.cases else st.text_input("Caso")
+                status = st.selectbox(
+                    "Status", ["Pendente", "Em andamento", "Concluída"]
+                )
+                submitted = st.form_submit_button("Salvar")
+                if submitted:
+                    add_task(title, due_date, related_case, status)
+                    st.success("Tarefa adicionada")
     st.subheader("Lista de Tarefas")
     if st.session_state.tasks:
         st.table(st.session_state.tasks)
@@ -166,16 +197,19 @@ elif menu == "Casos por Cliente":
 
 elif menu == "Financeiro":
     st.title("Financeiro")
-    with st.form("add_transaction"):
-        st.subheader("Adicionar Movimento")
-        kind = st.selectbox("Tipo", ["Entrada", "Saída"])
-        amount = st.number_input("Valor", min_value=0.0, step=0.01)
-        description = st.text_input("Descrição")
-        trans_date = st.date_input("Data", value=date.today())
-        submitted = st.form_submit_button("Adicionar")
-        if submitted:
-            add_transaction(kind, amount, description, trans_date)
-            st.success("Movimento adicionado")
+    if st.button("Adicionar Movimento"):
+        st.session_state.show_add_transaction = not st.session_state.show_add_transaction
+    if st.session_state.show_add_transaction:
+        with st.expander("Adicionar Movimento", expanded=True):
+            with st.form("add_transaction"):
+                kind = st.selectbox("Tipo", ["Entrada", "Saída"])
+                amount = st.number_input("Valor", min_value=0.0, step=0.01)
+                description = st.text_input("Descrição")
+                trans_date = st.date_input("Data", value=date.today())
+                submitted = st.form_submit_button("Salvar")
+                if submitted:
+                    add_transaction(kind, amount, description, trans_date)
+                    st.success("Movimento adicionado")
     st.subheader("Movimentos")
     if st.session_state.transactions:
         st.table(st.session_state.transactions)


### PR DESCRIPTION
## Summary
- show forms only after pressing each add button
- use Streamlit expanders to hide forms by default

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6872cb269fa48332989ad4e4a194a01e