### PR TITLE
Add expanded form fields and document section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ O painel possui as seguintes seções:
 - Visão Geral
 - Clientes
 - Casos
+- Documentos
 - Agenda
 - Tarefas
 - Casos por Cliente

--- a/app.py
+++ b/app.py
@@ -14,6 +14,8 @@ if 'events' not in st.session_state:
     st.session_state.events = []
 if 'transactions' not in st.session_state:
     st.session_state.transactions = []
+if 'documents' not in st.session_state:
+    st.session_state.documents = []
 
 if 'show_add_client' not in st.session_state:
     st.session_state.show_add_client = False
@@ -25,12 +27,19 @@ if 'show_add_event' not in st.session_state:
     st.session_state.show_add_event = False
 if 'show_add_transaction' not in st.session_state:
     st.session_state.show_add_transaction = False
+if 'show_add_document' not in st.session_state:
+    st.session_state.show_add_document = False
+if 'show_add_income' not in st.session_state:
+    st.session_state.show_add_income = False
+if 'show_add_expense' not in st.session_state:
+    st.session_state.show_add_expense = False
 
 menu = st.sidebar.selectbox(
     "Menu",[
         "Visão Geral",
         "Clientes",
         "Casos",
+        "Documentos",
         "Agenda",
         "Tarefas",
         "Casos por Cliente",
@@ -40,39 +49,63 @@ menu = st.sidebar.selectbox(
 
 # Funções auxiliares
 
-def add_client(name, email, phone):
-    st.session_state.clients.append({"Nome": name, "Email": email, "Telefone": phone})
+def add_client(name, email, phone, notes):
+    st.session_state.clients.append({
+        "Nome": name,
+        "Email": email,
+        "Telefone": phone,
+        "Anotações": notes,
+    })
 
-def add_case(title, client, description, status, start_date):
+def add_case(client, process_number, parties, lawyer, start_date, status):
     st.session_state.cases.append({
-        "Título": title,
         "Cliente": client,
-        "Descrição": description,
+        "Processo": process_number,
+        "Partes": parties,
+        "Advogado": lawyer,
+        "Data de Abertura": start_date,
         "Status": status,
-        "Data de início": start_date
     })
 
-def add_task(title, due_date, related_case, status):
+def add_task(description, priority, due_date, client, related_case):
     st.session_state.tasks.append({
-        "Título": title,
-        "Data limite": due_date,
+        "Descrição": description,
+        "Prioridade": priority,
+        "Prazo": due_date,
+        "Cliente": client,
         "Caso": related_case,
-        "Status": status
     })
 
-def add_event(title, event_date, description):
+def add_event(title, event_type, event_datetime, location, client, case, status, description):
     st.session_state.events.append({
         "Título": title,
-        "Data": event_date,
-        "Descrição": description
+        "Tipo": event_type,
+        "Data": event_datetime,
+        "Local": location,
+        "Cliente": client,
+        "Caso": case,
+        "Status": status,
+        "Descrição": description,
     })
 
-def add_transaction(kind, amount, description, trans_date):
+def add_transaction(kind, category, amount, description, trans_date, payment_status, client, case):
     st.session_state.transactions.append({
         "Tipo": kind,
+        "Categoria": category,
         "Valor": amount,
         "Descrição": description,
-        "Data": trans_date
+        "Data": trans_date,
+        "Status": payment_status,
+        "Cliente": client,
+        "Caso": case,
+    })
+
+def add_document(client, case, title, file):
+    st.session_state.documents.append({
+        "Cliente": client,
+        "Caso": case,
+        "Título": title,
+        "Arquivo": file.name if file else "",
     })
 
 # Páginas
@@ -97,12 +130,13 @@ elif menu == "Clientes":
     if st.session_state.show_add_client:
         with st.expander("Adicionar Cliente", expanded=True):
             with st.form("add_client"):
-                name = st.text_input("Nome")
-                email = st.text_input("Email")
+                name = st.text_input("Nome Completo *")
+                email = st.text_input("E-mail")
                 phone = st.text_input("Telefone")
+                notes = st.text_area("Anotações / Preferências")
                 submitted = st.form_submit_button("Salvar")
                 if submitted:
-                    add_client(name, email, phone)
+                    add_client(name, email, phone, notes)
                     st.success("Cliente adicionado")
     st.subheader("Lista de Clientes")
     if st.session_state.clients:
@@ -117,23 +151,52 @@ elif menu == "Casos":
     if st.session_state.show_add_case:
         with st.expander("Adicionar Caso", expanded=True):
             with st.form("add_case"):
-                title = st.text_input("Título")
                 client = st.selectbox(
-                    "Cliente",
+                    "Cliente *",
                     [c['Nome'] for c in st.session_state.clients]
-                ) if st.session_state.clients else st.text_input("Cliente")
-                description = st.text_area("Descrição")
-                status = st.selectbox("Status", ["Aberto", "Em andamento", "Fechado"])
-                start_date = st.date_input("Data de início", value=date.today())
+                ) if st.session_state.clients else st.text_input("Cliente *")
+                process_number = st.text_input("Nº do Processo *")
+                parties = st.text_area("Partes Envolvidas")
+                lawyer = st.text_input("Advogado Responsável")
+                start_date = st.date_input("Data de Abertura", value=date.today())
+                status = st.selectbox("Status", ["Ativo", "Encerrado", "Suspenso"])
                 submitted = st.form_submit_button("Salvar")
                 if submitted:
-                    add_case(title, client, description, status, start_date)
+                    add_case(client, process_number, parties, lawyer, start_date, status)
                     st.success("Caso adicionado")
     st.subheader("Lista de Casos")
     if st.session_state.cases:
         st.table(st.session_state.cases)
     else:
         st.info("Nenhum caso cadastrado")
+
+elif menu == "Documentos":
+    st.title("Documentos")
+    if st.button("Anexar Documento"):
+        st.session_state.show_add_document = not st.session_state.show_add_document
+    if st.session_state.show_add_document:
+        with st.expander("Anexar Documento", expanded=True):
+            with st.form("add_document"):
+                client = st.selectbox(
+                    "Cliente *",
+                    [c['Nome'] for c in st.session_state.clients]
+                ) if st.session_state.clients else st.text_input("Cliente *")
+                case = st.selectbox(
+                    "Vincular ao Caso (opcional)",
+                    ["Nenhum"] + [c['Processo'] for c in st.session_state.cases]
+                )
+                title = st.text_input("Título / Descrição *")
+                file = st.file_uploader("Arquivo *")
+                submitted = st.form_submit_button("Salvar")
+                if submitted:
+                    case_val = None if case == "Nenhum" else case
+                    add_document(client, case_val, title, file)
+                    st.success("Documento anexado")
+    st.subheader("Documentos")
+    if st.session_state.documents:
+        st.table([{k: v for k, v in d.items() if k != "Arquivo"} for d in st.session_state.documents])
+    else:
+        st.info("Nenhum documento anexado")
 
 elif menu == "Agenda":
     st.title("Agenda")
@@ -142,12 +205,27 @@ elif menu == "Agenda":
     if st.session_state.show_add_event:
         with st.expander("Adicionar Evento", expanded=True):
             with st.form("add_event"):
-                title = st.text_input("Título")
-                event_date = st.date_input("Data", value=date.today())
+                title = st.text_input("Título *")
+                event_type = st.selectbox("Tipo de Evento *", ["Audiência", "Prazo", "Reunião"])
+                event_day = st.date_input("Data *", value=date.today())
+                event_time = st.time_input("Hora *", value=datetime.now().time())
+                location = st.text_input("Local / Link")
+                client = st.selectbox(
+                    "Vincular ao Cliente",
+                    ["Nenhum"] + [c['Nome'] for c in st.session_state.clients]
+                )
+                case = st.selectbox(
+                    "Vincular ao Caso",
+                    ["Nenhum"] + [c['Processo'] for c in st.session_state.cases]
+                )
+                status = st.selectbox("Status", ["Agendado", "Concluído", "Cancelado"])
                 description = st.text_area("Descrição")
                 submitted = st.form_submit_button("Salvar")
                 if submitted:
-                    add_event(title, event_date, description)
+                    client_val = None if client == "Nenhum" else client
+                    case_val = None if case == "Nenhum" else case
+                    dt = datetime.combine(event_day, event_time)
+                    add_event(title, event_type, dt, location, client_val, case_val, status, description)
                     st.success("Evento adicionado")
     st.subheader("Eventos")
     if st.session_state.events:
@@ -162,18 +240,22 @@ elif menu == "Tarefas":
     if st.session_state.show_add_task:
         with st.expander("Adicionar Tarefa", expanded=True):
             with st.form("add_task"):
-                title = st.text_input("Título")
-                due_date = st.date_input("Data limite", value=date.today())
+                description = st.text_input("Descrição *")
+                priority = st.selectbox("Prioridade", ["Baixa", "Média", "Alta"])
+                due_date = st.date_input("Data do Prazo", value=date.today())
+                client = st.selectbox(
+                    "Vincular ao Cliente",
+                    ["Nenhum"] + [c['Nome'] for c in st.session_state.clients]
+                )
                 related_case = st.selectbox(
-                    "Caso",
-                    [c['Título'] for c in st.session_state.cases]
-                ) if st.session_state.cases else st.text_input("Caso")
-                status = st.selectbox(
-                    "Status", ["Pendente", "Em andamento", "Concluída"]
+                    "Vincular ao Caso",
+                    ["Nenhum"] + [c['Processo'] for c in st.session_state.cases]
                 )
                 submitted = st.form_submit_button("Salvar")
                 if submitted:
-                    add_task(title, due_date, related_case, status)
+                    client_val = None if client == "Nenhum" else client
+                    case_val = None if related_case == "Nenhum" else related_case
+                    add_task(description, priority, due_date, client_val, case_val)
                     st.success("Tarefa adicionada")
     st.subheader("Lista de Tarefas")
     if st.session_state.tasks:
@@ -197,19 +279,78 @@ elif menu == "Casos por Cliente":
 
 elif menu == "Financeiro":
     st.title("Financeiro")
-    if st.button("Adicionar Movimento"):
-        st.session_state.show_add_transaction = not st.session_state.show_add_transaction
-    if st.session_state.show_add_transaction:
-        with st.expander("Adicionar Movimento", expanded=True):
-            with st.form("add_transaction"):
-                kind = st.selectbox("Tipo", ["Entrada", "Saída"])
-                amount = st.number_input("Valor", min_value=0.0, step=0.01)
-                description = st.text_input("Descrição")
-                trans_date = st.date_input("Data", value=date.today())
+    col1, col2 = st.columns(2)
+    with col1:
+        if st.button("Registrar Receita"):
+            st.session_state.show_add_income = not st.session_state.show_add_income
+    with col2:
+        if st.button("Registrar Despesa"):
+            st.session_state.show_add_expense = not st.session_state.show_add_expense
+
+    if st.session_state.show_add_income:
+        with st.expander("Registrar Receita", expanded=True):
+            with st.form("add_income"):
+                category = st.text_input("Categoria *", value="Honorários")
+                amount = st.number_input("Valor (R$) *", min_value=0.0, step=0.01)
+                description = st.text_input("Descrição *")
+                trans_date = st.date_input("Data *", value=date.today())
+                payment_status = st.selectbox("Status Pagamento", ["Pendente", "Pago"])
+                client = st.selectbox(
+                    "Vincular ao Cliente",
+                    ["Nenhum"] + [c['Nome'] for c in st.session_state.clients]
+                )
+                case = st.selectbox(
+                    "Vincular ao Caso",
+                    ["Nenhum"] + [c['Processo'] for c in st.session_state.cases]
+                )
                 submitted = st.form_submit_button("Salvar")
                 if submitted:
-                    add_transaction(kind, amount, description, trans_date)
-                    st.success("Movimento adicionado")
+                    client_val = None if client == "Nenhum" else client
+                    case_val = None if case == "Nenhum" else case
+                    add_transaction(
+                        "Receita",
+                        category,
+                        amount,
+                        description,
+                        trans_date,
+                        payment_status,
+                        client_val,
+                        case_val,
+                    )
+                    st.success("Receita registrada")
+
+    if st.session_state.show_add_expense:
+        with st.expander("Registrar Despesa", expanded=True):
+            with st.form("add_expense"):
+                category = st.text_input("Categoria *", value="Honorários")
+                amount = st.number_input("Valor (R$) *", min_value=0.0, step=0.01)
+                description = st.text_input("Descrição *")
+                trans_date = st.date_input("Data *", value=date.today())
+                payment_status = st.selectbox("Status Pagamento", ["Pendente", "Pago"])
+                client = st.selectbox(
+                    "Vincular ao Cliente",
+                    ["Nenhum"] + [c['Nome'] for c in st.session_state.clients]
+                )
+                case = st.selectbox(
+                    "Vincular ao Caso",
+                    ["Nenhum"] + [c['Processo'] for c in st.session_state.cases]
+                )
+                submitted = st.form_submit_button("Salvar")
+                if submitted:
+                    client_val = None if client == "Nenhum" else client
+                    case_val = None if case == "Nenhum" else case
+                    add_transaction(
+                        "Despesa",
+                        category,
+                        amount,
+                        description,
+                        trans_date,
+                        payment_status,
+                        client_val,
+                        case_val,
+                    )
+                    st.success("Despesa registrada")
+
     st.subheader("Movimentos")
     if st.session_state.transactions:
         st.table(st.session_state.transactions)


### PR DESCRIPTION
## Summary
- expand all forms with additional fields
- add a Documents section for uploading files
- split Finance section into income and expense forms
- document new menu in README

## Testing
- `python -m py_compile app.py`
- `streamlit run app.py --server.headless true --server.port 8501` *(fails to detect external IP but app starts)*

------
https://chatgpt.com/codex/tasks/task_e_6872cd9d0f80833286f1919ced300927