### PR TITLE
Add calendar view

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Este repositório contém um painel em [Streamlit](https://streamlit.io/) para g
 
 1. Instale as dependências necessárias:
    ```bash
-   pip install streamlit streamlit-option-menu
+   pip install streamlit streamlit-option-menu streamlit-calendar
    ```
 2. Execute a aplicação com:
    ```bash

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import streamlit as st
 from datetime import datetime, date, time
 from streamlit_option_menu import option_menu
 import pandas as pd
+from streamlit_calendar import calendar as calendar_component
 
 st.set_page_config(page_title="Painel para Advogados", layout="wide")
 
@@ -471,6 +472,23 @@ if menu == "Visão Geral":
         for t in st.session_state.transactions
     )
     col4.metric("Saldo", f"R$ {saldo:,.2f}")
+    st.subheader("Calendário")
+    calendar_events = [
+        {
+            "title": e["Título"],
+            "start": e["Data"].isoformat(),
+            "color": EVENT_STATUS_COLORS.get(e["Status"], "gray"),
+        }
+        for e in st.session_state.events
+    ]
+    calendar_component(
+        events=calendar_events,
+        options={
+            "initialView": "dayGridMonth",
+            "locale": "pt-br",
+            "height": 500,
+        },
+    )
     st.subheader("Próximos eventos")
     if st.session_state.events:
         upcoming = sorted(st.session_state.events, key=lambda x: x["Data"])[:5]


### PR DESCRIPTION
## Summary
- add `streamlit-calendar` dependency in README
- show calendar with events on Visão Geral page

## Testing
- `python -m py_compile app.py`
- `streamlit run app.py --server.headless true --server.port 8501` *(fails: check external IP but server starts)*

------
https://chatgpt.com/codex/tasks/task_e_6872f57034bc8332a4477b01dc24c9a7