### PR TITLE
Add report export menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Este repositório contém um painel em [Streamlit](https://streamlit.io/) para g
 
 1. Instale as dependências necessárias:
    ```bash
-   pip install streamlit streamlit-option-menu streamlit-calendar
+   pip install streamlit streamlit-option-menu streamlit-calendar fpdf openpyxl
    ```
 2. Execute a aplicação com:
    ```bash
@@ -22,8 +22,11 @@ O painel possui as seguintes seções:
 - Tarefas
 - Casos por Cliente
 - Financeiro
+- Relatórios
 
 Cada seção permite cadastrar e visualizar informações relacionadas ao dia a dia do advogado.
+
+O menu **Relatórios** permite exportar a listagem de casos, documentos ou movimentos financeiros para arquivos Excel ou PDF.
 
 Os formulários agora utilizam `st.dialog` para exibir caixas de diálogo modais
 ao adicionar novos registros. Os formulários de edição também usam `st.dialog`.


### PR DESCRIPTION
## Summary
- add new menu item **Relatórios** with icon
- enable exporting cases, documents and financial movements to Excel or PDF
- include helper to build PDF tables using `fpdf`
- update README with new dependencies and section description

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6872face8ce08332b7e5390932522e09