### PR TITLE
Support Streamlit secret for Google credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ credenciais e defina a variável de ambiente `GOOGLE_CREDS` apontando para esse
 arquivo. Opcionalmente, defina `GOOGLE_SHEETS_FILE` com o nome da planilha e
 `GOOGLE_DRIVE_ROOT` com o nome da pasta raiz no Drive.
 
+Em vez de fornecer um caminho de arquivo, também é possível gravar todo o texto
+do JSON de credenciais em um secret do Streamlit Cloud chamado
+`GOOGLE_CREDS_JSON`. O código detecta automaticamente esse secret e cria um
+arquivo temporário para a autenticação, mantendo compatibilidade com o uso de
+`GOOGLE_CREDS`.
+
 O painel possui as seguintes seções:
 - Visão Geral
 - Clientes

--- a/google_utils.py
+++ b/google_utils.py
@@ -1,5 +1,7 @@
 import os
 import io
+import tempfile
+import streamlit as st
 from typing import List, Dict
 
 import gspread
@@ -23,10 +25,17 @@ _drive_service = None
 def get_credentials():
     global _creds
     if _creds is None:
-        creds_path = os.environ.get("GOOGLE_CREDS")
-        if not creds_path:
-            raise RuntimeError("Missing GOOGLE_CREDS environment variable")
-        _creds = Credentials.from_service_account_file(creds_path, scopes=SCOPES)
+        json_text = st.secrets.get("GOOGLE_CREDS_JSON")
+        if json_text:
+            with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as tmp:
+                tmp.write(json_text)
+                tmp_path = tmp.name
+            _creds = Credentials.from_service_account_file(tmp_path, scopes=SCOPES)
+        else:
+            creds_path = os.environ.get("GOOGLE_CREDS")
+            if not creds_path:
+                raise RuntimeError("Missing GOOGLE_CREDS or GOOGLE_CREDS_JSON")
+            _creds = Credentials.from_service_account_file(creds_path, scopes=SCOPES)
     return _creds
 
 


### PR DESCRIPTION
## Summary
- allow providing Google credentials JSON via the `GOOGLE_CREDS_JSON` secret
- document the new secret usage in the README

## Testing
- `python -m py_compile app.py google_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_687396cb099483329790c58d26a41760