### PR TITLE
Improve handling of invalid secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ conteúdo do JSON das credenciais:
 your_key = "..."
 ```
 
+**Importante**: copie o JSON exatamente como fornecido pelo Google. O campo
+`private_key` precisa conter quebras de linha escapadas com `\n`. Se colado com
+quebras de linha reais, ocorrerá erro "Invalid control character" ao ler as
+credenciais.
+
 Ao implantar no Streamlit Cloud, copie esse mesmo conteúdo para a seção **Secret**
 nas configurações avançadas do aplicativo. Certifique-se também de compartilhar a planilha e a pasta do Google Drive com o e-mail da conta de serviço para que o aplicativo tenha permissão de leitura e escrita.
 

--- a/google_utils.py
+++ b/google_utils.py
@@ -29,13 +29,13 @@ def get_credentials():
         json_data = st.secrets.get("GOOGLE_CREDS_JSON")
         if json_data:
             if isinstance(json_data, str):
-                json_text = json_data
+                try:
+                    creds_info = json.loads(json_data, strict=False)
+                except json.JSONDecodeError as e:
+                    raise RuntimeError(f"Invalid GOOGLE_CREDS_JSON: {e}") from e
             else:
-                json_text = json.dumps(json_data)
-            with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as tmp:
-                tmp.write(json_text)
-                tmp_path = tmp.name
-            _creds = Credentials.from_service_account_file(tmp_path, scopes=SCOPES)
+                creds_info = json_data
+            _creds = Credentials.from_service_account_info(creds_info, scopes=SCOPES)
         else:
             creds_path = os.environ.get("GOOGLE_CREDS")
             if not creds_path:


### PR DESCRIPTION
## Summary
- parse `GOOGLE_CREDS_JSON` with `json.loads(..., strict=False)` so secrets
  pasted with newline characters still work
- document the required `\n` escapes in `private_key`

## Testing
- `python3 -m py_compile app.py google_utils.py`
- `pip install -r requirements.txt --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6873b25c01e48332ab2314d8159f1564