### PR TITLE
Switch to Apps Script backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,42 +7,19 @@ Este repositório contém um painel em [Streamlit](https://streamlit.io/) para g
 1. Instale as dependências necessárias:
    ```bash
    pip install streamlit streamlit-option-menu streamlit-calendar fpdf openpyxl \
-       gspread google-api-python-client google-auth
+       requests
    ```
 2. Execute a aplicação com:
    ```bash
    streamlit run app.py
    ```
 
-Para persistir os dados em planilhas do Google Sheets e armazenar documentos no
-Google Drive, é necessário criar credenciais de uma **conta de serviço** no
-[Google Cloud Console](https://console.cloud.google.com/). Habilite as APIs
-**Google Sheets API** e **Google Drive API**, faça o download do arquivo JSON de
-credenciais e defina a variável de ambiente `GOOGLE_CREDS` apontando para esse
-arquivo. Opcionalmente, defina `GOOGLE_SHEETS_FILE` com o nome da planilha e
-`GOOGLE_DRIVE_ROOT` com o nome da pasta raiz no Drive.
-
-Em vez de fornecer um caminho de arquivo, também é possível gravar todo o texto
-do JSON de credenciais em um secret do Streamlit Cloud chamado
-`GOOGLE_CREDS_JSON`. O código detecta automaticamente esse secret e cria um
-arquivo temporário para a autenticação, mantendo compatibilidade com o uso de
-`GOOGLE_CREDS`.
-
-Para desenvolvimento local, crie um arquivo `.streamlit/secrets.toml` com o
-conteúdo do JSON das credenciais:
-
-```toml
-[GOOGLE_CREDS_JSON]
-your_key = "..."
-```
-
-**Importante**: copie o JSON exatamente como fornecido pelo Google. O campo
-`private_key` precisa conter quebras de linha escapadas com `\n`. Se colado com
-quebras de linha reais, ocorrerá erro "Invalid control character" ao ler as
-credenciais.
-
-Ao implantar no Streamlit Cloud, copie esse mesmo conteúdo para a seção **Secret**
-nas configurações avançadas do aplicativo. Certifique-se também de compartilhar a planilha e a pasta do Google Drive com o e-mail da conta de serviço para que o aplicativo tenha permissão de leitura e escrita.
+Este projeto utiliza um backend em **Google Apps Script** para manipular as
+planilhas e os documentos. Crie um projeto no Apps Script, implemente as ações
+necessárias (adicionar, editar, excluir e buscar dados) e publique-o como *Web
+App*. Defina a variável de ambiente `APPS_SCRIPT_URL` com o endereço do script
+implantado. Todas as operações de salvamento e upload feitas pelo painel serão
+enviadas para essa URL utilizando requisições HTTP.
 
 O painel possui as seguintes seções:
 - Visão Geral

--- a/google_utils.py
+++ b/google_utils.py
@@ -1,114 +1,50 @@
 import os
-import io
-import tempfile
 import json
+from typing import List, Dict, Optional
+
+import requests
 import streamlit as st
-from typing import List, Dict
 
-import gspread
-from google.oauth2.service_account import Credentials
-from googleapiclient.discovery import build
-from googleapiclient.http import MediaIoBaseUpload
-
-SCOPES = [
-    "https://www.googleapis.com/auth/spreadsheets",
-    "https://www.googleapis.com/auth/drive",
-]
-
-SPREADSHEET_NAME = os.environ.get("GOOGLE_SHEETS_FILE", "PlataformaAD_Dados")
-FOLDER_ROOT_NAME = os.environ.get("GOOGLE_DRIVE_ROOT", "PlataformaAD_Documentos")
-
-_creds = None
-_gc = None
-_drive_service = None
+APPS_SCRIPT_URL = os.environ.get("APPS_SCRIPT_URL") or st.secrets.get("APPS_SCRIPT_URL")
 
 
-def get_credentials():
-    global _creds
-    if _creds is None:
-        json_data = st.secrets.get("GOOGLE_CREDS_JSON")
-        if json_data:
-            if isinstance(json_data, str):
-                try:
-                    creds_info = json.loads(json_data, strict=False)
-                except json.JSONDecodeError as e:
-                    raise RuntimeError(f"Invalid GOOGLE_CREDS_JSON: {e}") from e
-            else:
-                creds_info = json_data
-            _creds = Credentials.from_service_account_info(creds_info, scopes=SCOPES)
-        else:
-            creds_path = os.environ.get("GOOGLE_CREDS")
-            if not creds_path:
-                raise RuntimeError("Missing GOOGLE_CREDS or GOOGLE_CREDS_JSON")
-            _creds = Credentials.from_service_account_file(creds_path, scopes=SCOPES)
-    return _creds
-
-
-def get_gspread_client():
-    global _gc
-    if _gc is None:
-        _gc = gspread.authorize(get_credentials())
-    return _gc
-
-
-def get_drive_service():
-    global _drive_service
-    if _drive_service is None:
-        _drive_service = build("drive", "v3", credentials=get_credentials())
-    return _drive_service
-
-
-def get_spreadsheet():
-    gc = get_gspread_client()
+def _call_apps_script(action: str, payload: Optional[dict] = None, files=None):
+    """Send a request to the configured Apps Script URL."""
+    if not APPS_SCRIPT_URL:
+        raise RuntimeError("APPS_SCRIPT_URL not configured")
+    data = {"action": action}
+    if payload:
+        data.update(payload)
+    resp = requests.post(APPS_SCRIPT_URL, data=data, files=files, timeout=30)
+    resp.raise_for_status()
     try:
-        return gc.open(SPREADSHEET_NAME)
-    except gspread.SpreadsheetNotFound:
-        return gc.create(SPREADSHEET_NAME)
-
-
-def get_worksheet(sheet_name: str):
-    sh = get_spreadsheet()
-    try:
-        return sh.worksheet(sheet_name)
-    except gspread.WorksheetNotFound:
-        return sh.add_worksheet(title=sheet_name, rows="100", cols="20")
+        return resp.json()
+    except ValueError:
+        return resp.text
 
 
 def append_rows(sheet_name: str, rows: List[List]):
-    ws = get_worksheet(sheet_name)
-    ws.append_rows(rows, value_input_option="USER_ENTERED")
+    """Append rows to a sheet via Apps Script."""
+    payload = {"sheet": sheet_name, "rows": json.dumps(rows)}
+    _call_apps_script("append_rows", payload)
 
 
 def load_rows(sheet_name: str) -> List[Dict]:
-    ws = get_worksheet(sheet_name)
-    records = ws.get_all_records()
-    return records
-
-
-def get_or_create_folder(name: str, parent_id: str = None) -> str:
-    drive = get_drive_service()
-    query = f"name='{name}' and mimeType='application/vnd.google-apps.folder' and trashed=false"
-    if parent_id:
-        query += f" and '{parent_id}' in parents"
-    res = drive.files().list(q=query, fields="files(id, name)").execute()
-    files = res.get("files", [])
-    if files:
-        return files[0]["id"]
-    metadata = {
-        "name": name,
-        "mimeType": "application/vnd.google-apps.folder",
-    }
-    if parent_id:
-        metadata["parents"] = [parent_id]
-    folder = drive.files().create(body=metadata, fields="id").execute()
-    return folder["id"]
+    """Load all rows from a sheet via Apps Script."""
+    payload = {"sheet": sheet_name}
+    result = _call_apps_script("load_rows", payload)
+    if isinstance(result, dict) and "data" in result:
+        return result["data"]
+    if isinstance(result, list):
+        return result
+    return []
 
 
 def upload_file(file_bytes: bytes, filename: str, client_name: str) -> str:
-    drive = get_drive_service()
-    root_id = get_or_create_folder(FOLDER_ROOT_NAME)
-    client_id = get_or_create_folder(client_name, parent_id=root_id)
-    media = MediaIoBaseUpload(io.BytesIO(file_bytes), mimetype="application/octet-stream")
-    file_metadata = {"name": filename, "parents": [client_id]}
-    f = drive.files().create(body=file_metadata, media_body=media, fields="id, webViewLink").execute()
-    return f.get("webViewLink")
+    """Upload a file via Apps Script and return the created link."""
+    files = {"file": (filename, file_bytes)}
+    payload = {"filename": filename, "client": client_name}
+    result = _call_apps_script("upload_file", payload, files=files)
+    if isinstance(result, dict):
+        return result.get("link", "")
+    return str(result)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,4 @@ streamlit-calendar
 pandas
 fpdf
 openpyxl
-gspread
-google-api-python-client
-google-auth
+requests


### PR DESCRIPTION
## Summary
- replace Google API utilities with Apps Script HTTP calls
- document Apps Script usage
- require `requests` instead of Google libraries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873b591b54c83328a46de64ca7a4800